### PR TITLE
ci: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
             -scheme Cookey \
             -configuration Debug \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -destination 'generic/platform=iOS Simulator' \
             -clonedSourcePackagesDirPath .spm \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \


### PR DESCRIPTION
Add CI/CD pipeline for building iOS App, CLI tool, and Server Docker image.

**Features:**
- iOS: macOS-14 + Xcode 15.4 + iPhone 15 simulator, code signing disabled for CI
- CLI: Ubuntu + Swift 5.9 with SPM package caching
- Server: Docker build with GitHub Actions layer caching
- Concurrency control to cancel outdated runs
- Triggers on push/PR to main and master branches

**Workflow jobs:**
1. iOS - Build and test on iOS Simulator
2. CLI - Build and test Swift package
3. Server - Build Docker image with cache optimization

Generated by Claude Opus 4.5.