### PR TITLE
feat: light/dark theme with WKWebView extending area support

### DIFF
--- a/Web/get-started.html
+++ b/Web/get-started.html
@@ -2,7 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)" />
     <title>Cookey — Get Started</title>
     <meta
       name="description"

--- a/Web/index.html
+++ b/Web/index.html
@@ -2,7 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)" />
     <title>Cookey — Give Your Agents the Cookey, Help Them In.</title>
     <meta
       name="description"

--- a/Web/src/components/Button.tsx
+++ b/Web/src/components/Button.tsx
@@ -4,7 +4,7 @@ const base =
   "inline-flex items-center gap-2 px-[22px] py-[11px] rounded-lg text-sm font-medium no-underline transition-opacity duration-150 hover:opacity-80";
 
 const variants = {
-  primary: "bg-ink text-black",
+  primary: "bg-ink text-bg",
   secondary: "bg-transparent text-muted border border-border",
 } as const;
 
@@ -49,7 +49,7 @@ export function Button({
       type="button"
       onClick={onClick}
       data-state={dataState}
-      className={`${base} border-0 font-[inherit] cursor-pointer ${variants[variant]} data-[state=copied]:bg-accent data-[state=copied]:text-black ${className ?? ""}`}
+      className={`${base} border-0 font-[inherit] cursor-pointer ${variants[variant]} data-[state=copied]:bg-accent data-[state=copied]:text-bg ${className ?? ""}`}
     >
       {children}
     </button>

--- a/Web/src/components/DetailsDisclosure.tsx
+++ b/Web/src/components/DetailsDisclosure.tsx
@@ -21,7 +21,7 @@ export default function DetailsDisclosure({
         onClick={() => setIsOpen(!isOpen)}
         aria-expanded={isOpen}
         aria-controls={panelId}
-        className="flex w-full items-center justify-between px-4 py-3 text-left transition-colors hover:bg-white/[0.02]"
+        className="flex w-full items-center justify-between px-4 py-3 text-left transition-colors hover:bg-ink/[0.03]"
       >
         <span className="flex items-center gap-2 text-sm font-medium text-muted">
           <svg aria-hidden="true" className="h-4 w-4 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>

--- a/Web/src/index.css
+++ b/Web/src/index.css
@@ -1,21 +1,21 @@
 @import "tailwindcss";
 
 @theme {
-  --color-bg: #0a0a0a;
-  --color-surface: #111111;
-  --color-border: rgba(255, 255, 255, 0.08);
-  --color-ink: #f0f0f0;
-  --color-muted: #888888;
-  --color-tag-bg: rgba(255, 255, 255, 0.06);
-  --color-accent: #4ade80;
-  --color-terminal-bg: #0d0d0d;
-  --color-terminal-bar: #1a1a1a;
+  --color-bg: #ffffff;
+  --color-surface: #f5f5f5;
+  --color-border: rgba(0, 0, 0, 0.1);
+  --color-ink: #171717;
+  --color-muted: #737373;
+  --color-tag-bg: rgba(0, 0, 0, 0.04);
+  --color-accent: #22c55e;
+  --color-terminal-bg: #f0f0f0;
+  --color-terminal-bar: #e5e5e5;
   --color-dot-red: #ff5f57;
   --color-dot-yellow: #febc2e;
   --color-dot-green: #28c840;
-  --color-code-prompt: #4ade80;
-  --color-code-rid: #a78bfa;
-  --color-code-url: #60a5fa;
+  --color-code-prompt: #16a34a;
+  --color-code-rid: #7c3aed;
+  --color-code-url: #2563eb;
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --font-mono: "SF Mono", "JetBrains Mono", "Fira Code", monospace;
   --breakpoint-xs: 600px;
@@ -24,9 +24,28 @@
 @layer base {
   html {
     scroll-behavior: smooth;
+    color-scheme: light dark;
   }
   body {
     -webkit-font-smoothing: antialiased;
+    background-color: var(--color-bg);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --color-bg: #0a0a0a;
+      --color-surface: #111111;
+      --color-border: rgba(255, 255, 255, 0.08);
+      --color-ink: #f0f0f0;
+      --color-muted: #888888;
+      --color-tag-bg: rgba(255, 255, 255, 0.06);
+      --color-accent: #4ade80;
+      --color-terminal-bg: #0d0d0d;
+      --color-terminal-bar: #1a1a1a;
+      --color-code-prompt: #4ade80;
+      --color-code-rid: #a78bfa;
+      --color-code-url: #60a5fa;
+    }
   }
 }
 

--- a/Web/test-login-do.html
+++ b/Web/test-login-do.html
@@ -2,7 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)" />
     <title>Cookey — Processing Login</title>
     <meta name="description" content="Processing login for Cookey App Store review." />
     <link rel="icon" href="/favicon.ico" sizes="48x48" />

--- a/Web/test-login-instruction.html
+++ b/Web/test-login-instruction.html
@@ -2,7 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)" />
     <title>Cookey — Test Login</title>
     <meta name="description" content="Test login page for Cookey App Store review." />
     <link rel="icon" href="/favicon.ico" sizes="48x48" />

--- a/Web/test-login-result.html
+++ b/Web/test-login-result.html
@@ -2,7 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)" />
     <title>Cookey — Login Result</title>
     <meta name="description" content="Login result for Cookey App Store review." />
     <link rel="icon" href="/favicon.ico" sizes="48x48" />

--- a/Web/test-login-site.html
+++ b/Web/test-login-site.html
@@ -2,7 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)" />
     <title>Test Login Site — Cookey</title>
     <meta name="description" content="Demo login site for Cookey App Store review testing." />
     <link rel="icon" href="/favicon.ico" sizes="48x48" />


### PR DESCRIPTION
## Summary

- Add dual light/dark theme support via `prefers-color-scheme` media query
- Add `theme-color` meta tags on all HTML pages so iOS WKWebView renders the correct extending area background color for both appearances
- Add `viewport-fit=cover` and `color-scheme: light dark` for proper iOS safe area and system control rendering
- Fix `text-black` → `text-bg` in Button component so primary buttons adapt to both themes

## Test plan

- [ ] Verify light theme renders correctly in browser (system set to light mode)
- [ ] Verify dark theme matches previous appearance exactly
- [ ] Open in iOS WKWebView and confirm extending area background matches page in both appearances
- [ ] Check primary buttons have proper contrast in both themes