### PR TITLE
[codex] Publish release workflow as non-draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -355,6 +355,7 @@ jobs:
         uses: softprops/action-gh-release@v2.6.1
         with:
           tag_name: ${{ needs.prepare.outputs.build_version }}
+          draft: false
           generate_release_notes: true
           files: build/release-assets/final/*
 


### PR DESCRIPTION
## Summary
- explicitly set `draft: false` for the GitHub release publishing step
- make the release workflow behavior independent of the action's default settings
- ensure Android release artifacts are included in a non-draft GitHub Release

## Why
The release workflow published the final GitHub Release without an explicit `draft` setting. This made the published state depend on the action default instead of repository intent.

## Validation
- parsed `.github/workflows/release.yml` with Ruby YAML loader
- inspected the workflow diff to confirm the change is limited to the release publish step
