### PR TITLE
[codex] Fix Android WebView back navigation

### DIFF
--- a/Frontend/Android/app/src/main/java/wiki/qaq/cookey/ui/browser/BrowserScreen.kt
+++ b/Frontend/Android/app/src/main/java/wiki/qaq/cookey/ui/browser/BrowserScreen.kt
@@ -3,6 +3,7 @@ package wiki.qaq.cookey.ui.browser
 import android.annotation.SuppressLint
 import android.net.Uri
 import android.webkit.*
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -53,6 +54,43 @@ private const val PASSKEY_DETECTION_JS = """
 })();
 """
 
+private const val HISTORY_BACK_GUARD_JS = """
+(function() {
+    if (window.__cookeyHistoryBackGuardInstalled) return;
+    window.__cookeyHistoryBackGuardInstalled = true;
+
+    var originalBack = window.history && window.history.back ? window.history.back.bind(window.history) : null;
+    var originalGo = window.history && window.history.go ? window.history.go.bind(window.history) : null;
+
+    function canGoBack(steps) {
+        try {
+            return window.history.length > Math.abs(steps);
+        } catch (e) {
+            return false;
+        }
+    }
+
+    if (originalBack) {
+        window.history.back = function() {
+            if (canGoBack(-1)) {
+                return originalBack();
+            }
+        };
+    }
+
+    if (originalGo) {
+        window.history.go = function(delta) {
+            if (typeof delta !== 'number' || delta >= 0) {
+                return originalGo(delta);
+            }
+            if (canGoBack(delta)) {
+                return originalGo(delta);
+            }
+        };
+    }
+})();
+"""
+
 @OptIn(ExperimentalMaterial3Api::class)
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
@@ -69,6 +107,16 @@ fun BrowserScreen(
     var showPasskeyAlert by remember { mutableStateOf(false) }
     val visitedUrls = remember { mutableStateListOf<String>() }
     val scope = rememberCoroutineScope()
+    val handleBackNavigation = {
+        val currentWebView = webView
+        if (currentWebView?.canGoBack() == true) {
+            currentWebView.goBack()
+        } else {
+            onBack()
+        }
+    }
+
+    BackHandler(onBack = handleBackNavigation)
 
     Scaffold(
         topBar = {
@@ -120,6 +168,8 @@ fun BrowserScreen(
                             recordVisitedUrl(url ?: view?.url?.toString(), visitedUrls)
                             // Inject passkey detection script
                             view?.evaluateJavascript(PASSKEY_DETECTION_JS, null)
+                            // Keep in-page JavaScript back navigation inside WebView history.
+                            view?.evaluateJavascript(HISTORY_BACK_GUARD_JS, null)
                         }
 
                         override fun shouldOverrideUrlLoading(


### PR DESCRIPTION
## Summary
- handle Android system back in the in-app browser via `BackHandler` so it navigates WebView history before exiting
- keep the top app bar back button as an immediate exit from the browser flow
- inject a small in-page history guard so site JS back actions stay within WebView history and do not fall through to app exit behavior

## Why
Android WebView browsing currently exits back to the app home screen too easily during login flows. The intended behavior is:
- top bar back exits immediately
- system back navigates browser history first
- in-page back links only affect WebView history

## Root Cause
`BrowserScreen` routed app-level back directly to `onBack()` instead of distinguishing WebView history from exiting the flow, and page-level JS history back had no guard when there was no available history entry.

## User Impact
Android login flows inside the in-app browser are less likely to drop the user back to the app home screen when a page or the system back button requests back navigation.

## Validation
- reviewed scoped diff for `BrowserScreen.kt`
- attempted `./gradlew :app:compileDebugKotlin`, but local validation is blocked in this environment because Android SDK configuration is missing (`ANDROID_HOME` / `Frontend/Android/local.properties`)
