### PR TITLE
feat(ios): enhance in-app browser with domain subtitle, gestures, and drawer popups

### DIFF
--- a/Frontend/Apple/Cookey/Interface/Browser/BrowserCaptureModel+Navigation.swift
+++ b/Frontend/Apple/Cookey/Interface/Browser/BrowserCaptureModel+Navigation.swift
@@ -18,6 +18,7 @@ extension BrowserCaptureModel: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
         pageTitle = webView.title ?? "Cookey"
+        pageDomain = webView.url?.host ?? ""
         if !initialLoadComplete {
             initialLoadComplete = true
         }

--- a/Frontend/Apple/Cookey/Interface/Browser/BrowserCaptureModel+UIDelegate.swift
+++ b/Frontend/Apple/Cookey/Interface/Browser/BrowserCaptureModel+UIDelegate.swift
@@ -7,9 +7,16 @@ extension BrowserCaptureModel: WKUIDelegate {
         _ webView: WKWebView,
         createWebViewWith configuration: WKWebViewConfiguration,
         for navigationAction: WKNavigationAction,
-        windowFeatures _: WKWindowFeatures
+        windowFeatures: WKWindowFeatures
     ) -> WKWebView? {
         if navigationAction.targetFrame == nil {
+            // If it's a regular target="_blank" link click without explicit popup dimensions,
+            // just load it in the current webview instead of opening a drawer.
+            if navigationAction.navigationType == .linkActivated && windowFeatures.width == nil && windowFeatures.height == nil {
+                webView.load(navigationAction.request)
+                return nil
+            }
+
             // Many OAuth providers use window.open to open a popup, and then use window.opener.postMessage
             // to send the token back to the main window. WKWebView natively breaks window.opener unless
             // the popup is actually created as a separate WKWebView instance and returned from this delegate method.
@@ -17,12 +24,31 @@ extension BrowserCaptureModel: WKUIDelegate {
             popupWebView.uiDelegate = self
             popupWebView.navigationDelegate = webView.navigationDelegate
             popupWebView.customUserAgent = webView.customUserAgent
+            popupWebView.allowsBackForwardNavigationGestures = true
             if #available(macOS 13.3, iOS 16.4, tvOS 16.4, *) {
                 popupWebView.isInspectable = webView.isInspectable
             }
 
-            webView.addSubview(popupWebView)
+            let popupVC = UIViewController()
+            popupVC.view.backgroundColor = .systemBackground
+            popupVC.view.addSubview(popupWebView)
             popupWebView.snp.makeConstraints { $0.edges.equalToSuperview() }
+
+            popupVC.navigationItem.rightBarButtonItem = UIBarButtonItem(
+                systemItem: .done,
+                primaryAction: UIAction { [weak popupVC] _ in
+                    popupVC?.dismiss(animated: true)
+                }
+            )
+
+            let navVC = UINavigationController(rootViewController: popupVC)
+
+            if let topVC = topViewController(for: webView.window) {
+                topVC.present(navVC, animated: true)
+            } else {
+                webView.addSubview(popupWebView)
+                popupWebView.snp.makeConstraints { $0.edges.equalToSuperview() }
+            }
 
             return popupWebView
         }
@@ -30,7 +56,11 @@ extension BrowserCaptureModel: WKUIDelegate {
     }
 
     func webViewDidClose(_ webView: WKWebView) {
-        webView.removeFromSuperview()
+        if let vc = findViewController(for: webView), vc.presentingViewController != nil {
+            vc.dismiss(animated: true)
+        } else {
+            webView.removeFromSuperview()
+        }
     }
 
     func webView(
@@ -87,12 +117,30 @@ extension BrowserCaptureModel: WKUIDelegate {
         on webView: WKWebView,
         fallback: @escaping () -> Void
     ) {
-        guard let viewController = webView.window?.rootViewController?.presentedViewController
-            ?? webView.window?.rootViewController
-        else {
+        guard let viewController = topViewController(for: webView.window) else {
             fallback()
             return
         }
         viewController.present(alert, animated: true)
+    }
+
+    private func topViewController(for window: UIWindow?) -> UIViewController? {
+        guard let window = window else { return nil }
+        var topVC = window.rootViewController
+        while let presented = topVC?.presentedViewController {
+            topVC = presented
+        }
+        return topVC
+    }
+
+    private func findViewController(for view: UIView) -> UIViewController? {
+        var responder: UIResponder? = view
+        while let next = responder?.next {
+            if let vc = next as? UIViewController {
+                return vc
+            }
+            responder = next
+        }
+        return nil
     }
 }

--- a/Frontend/Apple/Cookey/Interface/Browser/BrowserCaptureModel.swift
+++ b/Frontend/Apple/Cookey/Interface/Browser/BrowserCaptureModel.swift
@@ -46,7 +46,6 @@ final class BrowserCaptureModel: NSObject, ObservableObject, WKScriptMessageHand
         configuration.preferences.javaScriptCanOpenWindowsAutomatically = true
 
         Self.installPasskeyIntercept(on: configuration.userContentController)
-        Self.installViewportOverride(on: configuration.userContentController)
 
         webView = WKWebView(frame: .zero, configuration: configuration)
         webView.underPageBackgroundColor = .systemBackground
@@ -86,7 +85,6 @@ final class BrowserCaptureModel: NSObject, ObservableObject, WKScriptMessageHand
         }
 
         Self.installPasskeyIntercept(on: configuration.userContentController)
-        Self.installViewportOverride(on: configuration.userContentController)
 
         webView = WKWebView(frame: .zero, configuration: configuration)
         webView.underPageBackgroundColor = .systemBackground
@@ -281,44 +279,6 @@ final class BrowserCaptureModel: NSObject, ObservableObject, WKScriptMessageHand
     }
 
     // MARK: - Passkey Intercept
-
-    private static let viewportOverrideScript = """
-    (function() {
-        function fixViewport() {
-            var meta = document.querySelector('meta[name="viewport"]');
-            if (meta && meta.content.match(/viewport-fit=cover/i)) {
-                meta.content = meta.content.replace(/viewport-fit=cover/gi, 'viewport-fit=auto');
-            }
-        }
-        fixViewport();
-        var observer = new MutationObserver(function(mutations) {
-            mutations.forEach(function(mutation) {
-                if (mutation.type === 'childList') {
-                    for (var i = 0; i < mutation.addedNodes.length; i++) {
-                        var node = mutation.addedNodes[i];
-                        if (node.tagName === 'META' && node.name === 'viewport') {
-                            fixViewport();
-                        }
-                    }
-                } else if (mutation.type === 'attributes' && mutation.target.tagName === 'META' && mutation.target.name === 'viewport') {
-                    fixViewport();
-                }
-            });
-        });
-        if (document.documentElement) {
-            observer.observe(document.documentElement, { childList: true, subtree: true, attributes: true, attributeFilter: ['content'] });
-        }
-    })();
-    """
-
-    private static func installViewportOverride(on controller: WKUserContentController) {
-        let script = WKUserScript(
-            source: viewportOverrideScript,
-            injectionTime: .atDocumentEnd,
-            forMainFrameOnly: true
-        )
-        controller.addUserScript(script)
-    }
 
     private static let passkeyMessageHandler = "passkeyInterceptHandler"
 

--- a/Frontend/Apple/Cookey/Interface/Browser/BrowserCaptureModel.swift
+++ b/Frontend/Apple/Cookey/Interface/Browser/BrowserCaptureModel.swift
@@ -23,6 +23,7 @@ final class BrowserCaptureModel: NSObject, ObservableObject, WKScriptMessageHand
     @Published var errorMessage: String?
     @Published var isTransferring = false
     @Published var pageTitle = ""
+    @Published var pageDomain = ""
     @Published var passkeyAlertPresented = false
     @Published var initialLoadComplete = false
 
@@ -32,6 +33,7 @@ final class BrowserCaptureModel: NSObject, ObservableObject, WKScriptMessageHand
     init(targetURL: URL, deviceID: String) {
         self.targetURL = targetURL
         self.deviceID = deviceID
+        self.pageDomain = targetURL.host() ?? ""
         Logger.browser.infoFile("Creating browser capture model for target \(targetURL.host() ?? targetURL.absoluteString) without seed session")
 
         let configuration = WKWebViewConfiguration()
@@ -44,9 +46,11 @@ final class BrowserCaptureModel: NSObject, ObservableObject, WKScriptMessageHand
         configuration.preferences.javaScriptCanOpenWindowsAutomatically = true
 
         Self.installPasskeyIntercept(on: configuration.userContentController)
+        Self.installViewportOverride(on: configuration.userContentController)
 
         webView = WKWebView(frame: .zero, configuration: configuration)
         webView.underPageBackgroundColor = .systemBackground
+        webView.allowsBackForwardNavigationGestures = true
         if #available(macOS 13.3, iOS 16.4, tvOS 16.4, *) {
             webView.isInspectable = true
         }
@@ -60,6 +64,7 @@ final class BrowserCaptureModel: NSObject, ObservableObject, WKScriptMessageHand
     init(targetURL: URL, deviceID: String, seedSession: CapturedSession) {
         self.targetURL = targetURL
         self.deviceID = deviceID
+        self.pageDomain = targetURL.host() ?? ""
         Logger.browser.infoFile("Creating browser capture model for target \(targetURL.host() ?? targetURL.absoluteString) with seed session cookies=\(seedSession.cookies.count) origins=\(seedSession.origins.count)")
 
         let configuration = WKWebViewConfiguration()
@@ -81,9 +86,11 @@ final class BrowserCaptureModel: NSObject, ObservableObject, WKScriptMessageHand
         }
 
         Self.installPasskeyIntercept(on: configuration.userContentController)
+        Self.installViewportOverride(on: configuration.userContentController)
 
         webView = WKWebView(frame: .zero, configuration: configuration)
         webView.underPageBackgroundColor = .systemBackground
+        webView.allowsBackForwardNavigationGestures = true
         if #available(macOS 13.3, iOS 16.4, tvOS 16.4, *) {
             webView.isInspectable = true
         }
@@ -274,6 +281,44 @@ final class BrowserCaptureModel: NSObject, ObservableObject, WKScriptMessageHand
     }
 
     // MARK: - Passkey Intercept
+
+    private static let viewportOverrideScript = """
+    (function() {
+        function fixViewport() {
+            var meta = document.querySelector('meta[name="viewport"]');
+            if (meta && meta.content.match(/viewport-fit=cover/i)) {
+                meta.content = meta.content.replace(/viewport-fit=cover/gi, 'viewport-fit=auto');
+            }
+        }
+        fixViewport();
+        var observer = new MutationObserver(function(mutations) {
+            mutations.forEach(function(mutation) {
+                if (mutation.type === 'childList') {
+                    for (var i = 0; i < mutation.addedNodes.length; i++) {
+                        var node = mutation.addedNodes[i];
+                        if (node.tagName === 'META' && node.name === 'viewport') {
+                            fixViewport();
+                        }
+                    }
+                } else if (mutation.type === 'attributes' && mutation.target.tagName === 'META' && mutation.target.name === 'viewport') {
+                    fixViewport();
+                }
+            });
+        });
+        if (document.documentElement) {
+            observer.observe(document.documentElement, { childList: true, subtree: true, attributes: true, attributeFilter: ['content'] });
+        }
+    })();
+    """
+
+    private static func installViewportOverride(on controller: WKUserContentController) {
+        let script = WKUserScript(
+            source: viewportOverrideScript,
+            injectionTime: .atDocumentEnd,
+            forMainFrameOnly: true
+        )
+        controller.addUserScript(script)
+    }
 
     private static let passkeyMessageHandler = "passkeyInterceptHandler"
 

--- a/Frontend/Apple/Cookey/ViewControllers/BrowserViewController.swift
+++ b/Frontend/Apple/Cookey/ViewControllers/BrowserViewController.swift
@@ -20,6 +20,24 @@ class BrowserViewController: UIViewController {
 
     private let activityIndicator = UIActivityIndicatorView(style: .medium)
 
+    private let titleLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: 17, weight: .semibold)
+        $0.textAlignment = .center
+        $0.lineBreakMode = .byTruncatingTail
+    }
+
+    private let subtitleLabel = UILabel().then {
+        $0.font = .systemFont(ofSize: 12)
+        $0.textColor = .secondaryLabel
+        $0.textAlignment = .center
+        $0.lineBreakMode = .byTruncatingTail
+    }
+
+    private lazy var titleStackView = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel]).then {
+        $0.axis = .vertical
+        $0.alignment = .center
+    }
+
     init(deepLink: DeepLink, sessionModel: SessionUploadModel) {
         self.deepLink = deepLink
         self.sessionModel = sessionModel
@@ -44,6 +62,12 @@ class BrowserViewController: UIViewController {
         edgesForExtendedLayout = .all
         extendedLayoutIncludesOpaqueBars = true
 
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithDefaultBackground()
+        navigationItem.standardAppearance = appearance
+        navigationItem.scrollEdgeAppearance = appearance
+        navigationItem.compactAppearance = appearance
+
         browser.webView.alpha = 0
         view.addSubview(browser.webView)
         browser.webView.snp.makeConstraints { $0.edges.equalTo(view) }
@@ -65,6 +89,7 @@ class BrowserViewController: UIViewController {
             action: #selector(backTapped)
         )
         navigationItem.rightBarButtonItem = sendButton
+        navigationItem.titleView = titleStackView
         title = String(localized: "Browser")
 
         bindModel()
@@ -95,10 +120,13 @@ class BrowserViewController: UIViewController {
             }
             .store(in: &cancellables)
 
-        browser.$pageTitle
+        Publishers.CombineLatest(browser.$pageTitle, browser.$pageDomain)
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] pageTitle in
+            .sink { [weak self] pageTitle, pageDomain in
                 self?.title = pageTitle.isEmpty ? String(localized: "Browser") : pageTitle
+                self?.titleLabel.text = pageTitle.isEmpty ? String(localized: "Browser") : pageTitle
+                self?.subtitleLabel.text = pageDomain
+                self?.subtitleLabel.isHidden = pageDomain.isEmpty
             }
             .store(in: &cancellables)
 


### PR DESCRIPTION
## Summary
- **Domain Subtitle**: Displays the current page domain in the navigation bar below the title.
- **Swipe Gestures**: Enabled `allowsBackForwardNavigationGestures` on WKWebView to support Safari-like swipe to go back or forward.
- **Drawer Popups**: OAuth and other `window.open` popups now present in a dedicated `UINavigationController` (bottom sheet drawer) with a "Done" button, instead of being added directly as a subview. Regular `target="_blank"` links open within the same view.
- **Safari-like Scrolling**: Forced `viewport-fit=auto` on pages using `viewport-fit=cover` (e.g., X.com) and enabled the translucent navigation bar appearance, so content is initially offset below the navigation bar but scrolls nicely beneath it with a blur effect.

## Test plan
- Verify that opening the browser displays the domain correctly.
- Verify swipe gestures for navigation history work.
- Test OAuth login flow (e.g. Google) to ensure popups open in a dismissible drawer.
- Verify websites like X.com render properly below the navigation bar and blur under it when scrolling.

Made with [Cursor](https://cursor.com)