### PR TITLE
Add Android Play publishing to release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,21 @@ name: CI
 
 on:
   pull_request:
+    paths:
+      - .github/workflows/ci.yml
+      - .github/workflows/release.yml
+      - Frontend/Android/**
+      - Scripts/resolve-android-version.sh
+      - Scripts/publish-android-to-play.sh
   push:
     branches:
       - main
+    paths:
+      - .github/workflows/ci.yml
+      - .github/workflows/release.yml
+      - Frontend/Android/**
+      - Scripts/resolve-android-version.sh
+      - Scripts/publish-android-to-play.sh
   workflow_dispatch:
 
 concurrency:
@@ -43,199 +55,3 @@ jobs:
           name: cookey-android-debug-apk
           path: Frontend/Android/app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
-
-  ios:
-    name: iOS Build
-    runs-on: macos-26
-    defaults:
-      run:
-        working-directory: Frontend/Apple
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install xcbeautify
-        run: brew install xcbeautify
-
-      - name: Select Xcode 26.3
-        run: sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
-
-      - name: Cache Xcode Swift packages
-        uses: actions/cache@v4
-        with:
-          path: Frontend/Apple/.spm
-          key: ${{ runner.os }}-xcode-spm-${{ hashFiles('Frontend/Apple/Cookey.xcodeproj/project.pbxproj', 'Frontend/Apple/**/Package.resolved') }}
-          restore-keys: ${{ runner.os }}-xcode-spm-
-
-      - name: Resolve iOS package dependencies
-        run: |
-          set -o pipefail
-          xcodebuild \
-            -resolvePackageDependencies \
-            -project Cookey.xcodeproj \
-            -scheme Cookey \
-            -clonedSourcePackagesDirPath .spm \
-            | xcbeautify
-
-      - name: Build iOS app with ad-hoc signing
-        run: |
-          set -o pipefail
-          xcodebuild \
-            -project Cookey.xcodeproj \
-            -scheme Cookey \
-            -configuration Debug \
-            -sdk iphonesimulator \
-            -destination 'generic/platform=iOS Simulator' \
-            -clonedSourcePackagesDirPath .spm \
-            AD_HOC_CODE_SIGNING_ALLOWED=YES \
-            CODE_SIGN_IDENTITY=- \
-            build \
-            | xcbeautify
-
-  ios-tests:
-    name: iOS Tests (${{ matrix.shard.name }})
-    runs-on: macos-26
-    env:
-      IOS_TEST_DESTINATION: platform=iOS Simulator,name=iPhone 17,OS=26.2
-    strategy:
-      fail-fast: false
-      matrix:
-        shard:
-          - name: Browser + Session
-            test_args: >-
-              -only-testing:CookeyTests/BrowserCaptureModelTests
-              -only-testing:CookeyTests/CapturedSessionCodingTests
-              -only-testing:CookeyTests/CryptoBoxOpenTests
-          - name: Keys + Storage
-            test_args: >-
-              -only-testing:CookeyTests/DeviceKeyManagerTests
-              -only-testing:CookeyTests/KeyFingerprintTests
-              -only-testing:CookeyTests/LogStoreTests
-          - name: App Flows
-            test_args: >-
-              -only-testing:CookeyTests/CookeyTests
-              -only-testing:CookeyTests/DeepLinkTests
-    defaults:
-      run:
-        working-directory: Frontend/Apple
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install xcbeautify
-        run: brew install xcbeautify
-
-      - name: Select Xcode 26.3
-        run: sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
-
-      - name: Cache Xcode Swift packages
-        uses: actions/cache@v4
-        with:
-          path: Frontend/Apple/.spm
-          key: ${{ runner.os }}-xcode-spm-${{ hashFiles('Frontend/Apple/Cookey.xcodeproj/project.pbxproj', 'Frontend/Apple/**/Package.resolved') }}
-          restore-keys: ${{ runner.os }}-xcode-spm-
-
-      - name: Resolve iOS package dependencies
-        run: |
-          set -o pipefail
-          xcodebuild \
-            -resolvePackageDependencies \
-            -project Cookey.xcodeproj \
-            -scheme Cookey \
-            -clonedSourcePackagesDirPath .spm \
-            | xcbeautify
-
-      - name: Run iOS tests with ad-hoc signing
-        run: |
-          set -o pipefail
-          xcodebuild \
-            -project Cookey.xcodeproj \
-            -scheme Cookey \
-            -configuration Debug \
-            -destination "${IOS_TEST_DESTINATION}" \
-            -clonedSourcePackagesDirPath .spm \
-            -parallel-testing-enabled YES \
-            AD_HOC_CODE_SIGNING_ALLOWED=YES \
-            CODE_SIGN_IDENTITY=- \
-            test \
-            ${{ matrix.shard.test_args }} \
-            | xcbeautify
-
-  cli:
-    name: CLI Build
-    runs-on: macos-26
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: CommandLineTool/go.mod
-
-      - name: Build and test CLI
-        run: |
-          cd CommandLineTool
-          go build ./...
-          go test ./...
-
-  web:
-    name: Web Build
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: Web
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: Web/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Typecheck
-        run: npm run typecheck
-
-      - name: Build
-        run: npm run build
-
-  web-docker:
-    name: Web Docker Build
-    runs-on: ubuntu-latest
-    needs: web
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build web Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: Web
-          file: Web/Dockerfile
-          push: false
-          tags: cookey-web:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-  server-docker:
-    name: Server Docker Build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build server Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: Server
-          file: Server/Dockerfile
-          push: false
-          tags: cookey-server:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,21 +2,9 @@ name: CI
 
 on:
   pull_request:
-    paths:
-      - .github/workflows/ci.yml
-      - .github/workflows/release.yml
-      - Frontend/Android/**
-      - Scripts/resolve-android-version.sh
-      - Scripts/publish-android-to-play.sh
   push:
     branches:
       - main
-    paths:
-      - .github/workflows/ci.yml
-      - .github/workflows/release.yml
-      - Frontend/Android/**
-      - Scripts/resolve-android-version.sh
-      - Scripts/publish-android-to-play.sh
   workflow_dispatch:
 
 concurrency:
@@ -55,3 +43,199 @@ jobs:
           name: cookey-android-debug-apk
           path: Frontend/Android/app/build/outputs/apk/debug/app-debug.apk
           if-no-files-found: error
+
+  ios:
+    name: iOS Build
+    runs-on: macos-26
+    defaults:
+      run:
+        working-directory: Frontend/Apple
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install xcbeautify
+        run: brew install xcbeautify
+
+      - name: Select Xcode 26.3
+        run: sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
+
+      - name: Cache Xcode Swift packages
+        uses: actions/cache@v4
+        with:
+          path: Frontend/Apple/.spm
+          key: ${{ runner.os }}-xcode-spm-${{ hashFiles('Frontend/Apple/Cookey.xcodeproj/project.pbxproj', 'Frontend/Apple/**/Package.resolved') }}
+          restore-keys: ${{ runner.os }}-xcode-spm-
+
+      - name: Resolve iOS package dependencies
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -resolvePackageDependencies \
+            -project Cookey.xcodeproj \
+            -scheme Cookey \
+            -clonedSourcePackagesDirPath .spm \
+            | xcbeautify
+
+      - name: Build iOS app with ad-hoc signing
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project Cookey.xcodeproj \
+            -scheme Cookey \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination 'generic/platform=iOS Simulator' \
+            -clonedSourcePackagesDirPath .spm \
+            AD_HOC_CODE_SIGNING_ALLOWED=YES \
+            CODE_SIGN_IDENTITY=- \
+            build \
+            | xcbeautify
+
+  ios-tests:
+    name: iOS Tests (${{ matrix.shard.name }})
+    runs-on: macos-26
+    env:
+      IOS_TEST_DESTINATION: platform=iOS Simulator,name=iPhone 17,OS=26.2
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - name: Browser + Session
+            test_args: >-
+              -only-testing:CookeyTests/BrowserCaptureModelTests
+              -only-testing:CookeyTests/CapturedSessionCodingTests
+              -only-testing:CookeyTests/CryptoBoxOpenTests
+          - name: Keys + Storage
+            test_args: >-
+              -only-testing:CookeyTests/DeviceKeyManagerTests
+              -only-testing:CookeyTests/KeyFingerprintTests
+              -only-testing:CookeyTests/LogStoreTests
+          - name: App Flows
+            test_args: >-
+              -only-testing:CookeyTests/CookeyTests
+              -only-testing:CookeyTests/DeepLinkTests
+    defaults:
+      run:
+        working-directory: Frontend/Apple
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install xcbeautify
+        run: brew install xcbeautify
+
+      - name: Select Xcode 26.3
+        run: sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
+
+      - name: Cache Xcode Swift packages
+        uses: actions/cache@v4
+        with:
+          path: Frontend/Apple/.spm
+          key: ${{ runner.os }}-xcode-spm-${{ hashFiles('Frontend/Apple/Cookey.xcodeproj/project.pbxproj', 'Frontend/Apple/**/Package.resolved') }}
+          restore-keys: ${{ runner.os }}-xcode-spm-
+
+      - name: Resolve iOS package dependencies
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -resolvePackageDependencies \
+            -project Cookey.xcodeproj \
+            -scheme Cookey \
+            -clonedSourcePackagesDirPath .spm \
+            | xcbeautify
+
+      - name: Run iOS tests with ad-hoc signing
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project Cookey.xcodeproj \
+            -scheme Cookey \
+            -configuration Debug \
+            -destination "${IOS_TEST_DESTINATION}" \
+            -clonedSourcePackagesDirPath .spm \
+            -parallel-testing-enabled YES \
+            AD_HOC_CODE_SIGNING_ALLOWED=YES \
+            CODE_SIGN_IDENTITY=- \
+            test \
+            ${{ matrix.shard.test_args }} \
+            | xcbeautify
+
+  cli:
+    name: CLI Build
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: CommandLineTool/go.mod
+
+      - name: Build and test CLI
+        run: |
+          cd CommandLineTool
+          go build ./...
+          go test ./...
+
+  web:
+    name: Web Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: Web
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: Web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
+  web-docker:
+    name: Web Docker Build
+    runs-on: ubuntu-latest
+    needs: web
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build web Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: Web
+          file: Web/Dockerfile
+          push: false
+          tags: cookey-web:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  server-docker:
+    name: Server Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build server Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: Server
+          file: Server/Dockerfile
+          push: false
+          tags: cookey-server:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,6 +248,18 @@ jobs:
             Frontend/Android/build/release-exports/android/cookey-android.aab
           if-no-files-found: error
 
+      - name: Publish Android internal release to Google Play
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64 }}
+        run: |
+          set -euo pipefail
+          zsh ../../Scripts/publish-android-to-play.sh \
+            --package-name "wiki.qaq.cookey" \
+            --track "internal" \
+            --bundle-file "app/build/outputs/bundle/release/app-release.aab" \
+            --release-name "${{ steps.android_version.outputs.version_name }}" \
+            --version-code "${{ steps.android_version.outputs.version_code }}"
+
   sign_notarize_macos:
     if: github.actor == 'Lakr233' || github.actor == 'eyhn'
     name: Sign and notarize macOS CLI
@@ -348,7 +360,7 @@ jobs:
           #   Web/get-started.html, Web/llms.txt, skills.md
           (
             cd build/release-assets/final
-            sha256sum cookey-macOS.zip cookey-linux-x86_64.zip cookey-linux-aarch64.zip cookey-android.apk cookey-android.aab skills.md > checksums.txt
+            find . -maxdepth 1 -type f ! -name checksums.txt -print0 | sort -z | xargs -0 sha256sum > checksums.txt
           )
 
       - name: Publish GitHub release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           echo "artifact_name=cookey-${VERSION}-unsigned" >> "$GITHUB_OUTPUT"
 
   build_macos:
-    if: false # Debug: isolate Android release workflow
+    if: github.actor == 'Lakr233' || github.actor == 'eyhn'
     name: Build macOS CLI
     runs-on: macos-26
     needs: prepare
@@ -74,7 +74,7 @@ jobs:
           if-no-files-found: error
 
   build_linux_x86_64:
-    if: false # Debug: isolate Android release workflow
+    if: github.actor == 'Lakr233' || github.actor == 'eyhn'
     name: Build Linux x86_64 CLI
     runs-on: ubuntu-latest
     needs: prepare
@@ -108,7 +108,7 @@ jobs:
           if-no-files-found: error
 
   build_linux_aarch64:
-    if: false # Debug: isolate Android release workflow
+    if: github.actor == 'Lakr233' || github.actor == 'eyhn'
     name: Build Linux aarch64 CLI
     runs-on: ubuntu-24.04-arm
     needs: prepare
@@ -261,7 +261,7 @@ jobs:
             --version-code "${{ steps.android_version.outputs.version_code }}"
 
   sign_notarize_macos:
-    if: false # Debug: isolate Android release workflow
+    if: github.actor == 'Lakr233' || github.actor == 'eyhn'
     name: Sign and notarize macOS CLI
     runs-on: macos-26
     needs: [prepare, build_macos]
@@ -315,9 +315,30 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - prepare
+      - build_linux_x86_64
+      - build_linux_aarch64
       - build_android
+      - sign_notarize_macos
     steps:
       - uses: actions/checkout@v4
+
+      - name: Download macOS artifact
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: cookey-${{ needs.prepare.outputs.build_version }}-macOS
+          path: build/release-assets/macos
+
+      - name: Download Linux x86_64 artifact
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: cookey-${{ needs.prepare.outputs.build_version }}-linux-x86_64
+          path: build/release-assets/linux-x86_64
+
+      - name: Download Linux aarch64 artifact
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: cookey-${{ needs.prepare.outputs.build_version }}-linux-aarch64
+          path: build/release-assets/linux-aarch64
 
       - name: Download Android artifact
         uses: actions/download-artifact@v8.0.1
@@ -329,6 +350,9 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p build/release-assets/final
+          cp "build/release-assets/macos/cookey-${{ needs.prepare.outputs.build_version }}-macOS-cli.zip" "build/release-assets/final/cookey-macOS.zip"
+          cp "build/release-assets/linux-x86_64/cookey-${{ needs.prepare.outputs.build_version }}-linux-x86_64.zip" "build/release-assets/final/cookey-linux-x86_64.zip"
+          cp "build/release-assets/linux-aarch64/cookey-${{ needs.prepare.outputs.build_version }}-linux-aarch64.zip" "build/release-assets/final/cookey-linux-aarch64.zip"
           cp "build/release-assets/android/cookey-android.apk" "build/release-assets/final/cookey-android.apk"
           cp "build/release-assets/android/cookey-android.aab" "build/release-assets/final/cookey-android.aab"
           cp skills/website-login/SKILL.md build/release-assets/final/skills.md
@@ -348,7 +372,7 @@ jobs:
           files: build/release-assets/final/*
 
   build_packages:
-    if: false # Debug: isolate Android release workflow
+    if: github.actor == 'Lakr233' || github.actor == 'eyhn'
     name: Build npm and pip packages
     runs-on: ubuntu-latest
     needs: prepare
@@ -405,7 +429,7 @@ jobs:
           retention-days: 14
 
   publish_npm:
-    if: false # Debug: isolate Android release workflow
+    if: github.actor == 'Lakr233' || github.actor == 'eyhn'
     name: Publish npm packages
     needs: [prepare, build_packages]
     runs-on: ubuntu-latest
@@ -443,7 +467,7 @@ jobs:
         run: node ./scripts/publish-npm-packages.mjs --skip-build
 
   publish_pypi:
-    if: false # Debug: isolate Android release workflow
+    if: github.actor == 'Lakr233' || github.actor == 'eyhn'
     name: Publish PyPI package
     needs: [prepare, build_packages]
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           echo "artifact_name=cookey-${VERSION}-unsigned" >> "$GITHUB_OUTPUT"
 
   build_macos:
-    if: github.actor == 'Lakr233' || github.actor == 'eyhn'
+    if: false # Debug: isolate Android release workflow
     name: Build macOS CLI
     runs-on: macos-26
     needs: prepare
@@ -74,7 +74,7 @@ jobs:
           if-no-files-found: error
 
   build_linux_x86_64:
-    if: github.actor == 'Lakr233' || github.actor == 'eyhn'
+    if: false # Debug: isolate Android release workflow
     name: Build Linux x86_64 CLI
     runs-on: ubuntu-latest
     needs: prepare
@@ -108,7 +108,7 @@ jobs:
           if-no-files-found: error
 
   build_linux_aarch64:
-    if: github.actor == 'Lakr233' || github.actor == 'eyhn'
+    if: false # Debug: isolate Android release workflow
     name: Build Linux aarch64 CLI
     runs-on: ubuntu-24.04-arm
     needs: prepare
@@ -261,7 +261,7 @@ jobs:
             --version-code "${{ steps.android_version.outputs.version_code }}"
 
   sign_notarize_macos:
-    if: github.actor == 'Lakr233' || github.actor == 'eyhn'
+    if: false # Debug: isolate Android release workflow
     name: Sign and notarize macOS CLI
     runs-on: macos-26
     needs: [prepare, build_macos]
@@ -315,30 +315,9 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - prepare
-      - build_linux_x86_64
-      - build_linux_aarch64
       - build_android
-      - sign_notarize_macos
     steps:
       - uses: actions/checkout@v4
-
-      - name: Download macOS artifact
-        uses: actions/download-artifact@v8.0.1
-        with:
-          name: cookey-${{ needs.prepare.outputs.build_version }}-macOS
-          path: build/release-assets/macos
-
-      - name: Download Linux x86_64 artifact
-        uses: actions/download-artifact@v8.0.1
-        with:
-          name: cookey-${{ needs.prepare.outputs.build_version }}-linux-x86_64
-          path: build/release-assets/linux-x86_64
-
-      - name: Download Linux aarch64 artifact
-        uses: actions/download-artifact@v8.0.1
-        with:
-          name: cookey-${{ needs.prepare.outputs.build_version }}-linux-aarch64
-          path: build/release-assets/linux-aarch64
 
       - name: Download Android artifact
         uses: actions/download-artifact@v8.0.1
@@ -350,9 +329,6 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p build/release-assets/final
-          cp "build/release-assets/macos/cookey-${{ needs.prepare.outputs.build_version }}-macOS-cli.zip" "build/release-assets/final/cookey-macOS.zip"
-          cp "build/release-assets/linux-x86_64/cookey-${{ needs.prepare.outputs.build_version }}-linux-x86_64.zip" "build/release-assets/final/cookey-linux-x86_64.zip"
-          cp "build/release-assets/linux-aarch64/cookey-${{ needs.prepare.outputs.build_version }}-linux-aarch64.zip" "build/release-assets/final/cookey-linux-aarch64.zip"
           cp "build/release-assets/android/cookey-android.apk" "build/release-assets/final/cookey-android.apk"
           cp "build/release-assets/android/cookey-android.aab" "build/release-assets/final/cookey-android.aab"
           cp skills/website-login/SKILL.md build/release-assets/final/skills.md
@@ -372,7 +348,7 @@ jobs:
           files: build/release-assets/final/*
 
   build_packages:
-    if: github.actor == 'Lakr233' || github.actor == 'eyhn'
+    if: false # Debug: isolate Android release workflow
     name: Build npm and pip packages
     runs-on: ubuntu-latest
     needs: prepare
@@ -429,7 +405,7 @@ jobs:
           retention-days: 14
 
   publish_npm:
-    if: github.actor == 'Lakr233' || github.actor == 'eyhn'
+    if: false # Debug: isolate Android release workflow
     name: Publish npm packages
     needs: [prepare, build_packages]
     runs-on: ubuntu-latest
@@ -467,7 +443,7 @@ jobs:
         run: node ./scripts/publish-npm-packages.mjs --skip-build
 
   publish_pypi:
-    if: github.actor == 'Lakr233' || github.actor == 'eyhn'
+    if: false # Debug: isolate Android release workflow
     name: Publish PyPI package
     needs: [prepare, build_packages]
     runs-on: ubuntu-latest

--- a/Frontend/Android/SIGNING.md
+++ b/Frontend/Android/SIGNING.md
@@ -49,6 +49,7 @@ For GitHub Actions, the common pattern is:
 - Export the four variables above before calling Gradle.
 - Grant the Play service account access to the app and `Release apps to testing tracks` so CI can query the latest published `versionCode`.
 - The release workflow strips the leading `v` from the Git tag for `versionName`, then sets `versionCode` to `max(existing Play versionCodes) + 1`.
+- The release workflow uploads the signed `.aab` to the Google Play `internal` track after storing both the `.apk` and `.aab` in GitHub Actions artifacts.
 
 Example command to produce the Base64 payload locally:
 

--- a/Scripts/publish-android-to-play.sh
+++ b/Scripts/publish-android-to-play.sh
@@ -91,9 +91,9 @@ import pathlib
 import subprocess
 import tempfile
 import time
-import urllib.error
 import urllib.parse
 import urllib.request
+import urllib.error
 
 
 def b64url(data: bytes) -> bytes:
@@ -145,6 +145,19 @@ def build_token(service_account: dict) -> str:
         return json.loads(response.read())["access_token"]
 
 
+class ApiHttpError(RuntimeError):
+    def __init__(self, method: str, url: str, status_code: int, reason: str, body: str):
+        message = f"{method} {url} failed: {status_code} {reason}"
+        if body.strip():
+            message = f"{message}\n{body}"
+        super().__init__(message)
+        self.method = method
+        self.url = url
+        self.status_code = status_code
+        self.reason = reason
+        self.body = body
+
+
 def api_json(token: str, method: str, url: str, data=None, content_type: str = "application/json"):
     payload = data
     if data is not None and isinstance(data, (dict, list)):
@@ -158,9 +171,13 @@ def api_json(token: str, method: str, url: str, data=None, content_type: str = "
             "Content-Type": content_type,
         },
     )
-    with urllib.request.urlopen(request) as response:
-        body = response.read()
-        return json.loads(body) if body else None
+    try:
+        with urllib.request.urlopen(request) as response:
+            body = response.read()
+            return json.loads(body) if body else None
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise ApiHttpError(method, url, exc.code, exc.reason, body) from exc
 
 
 service_account = json.loads(pathlib.Path(os.environ["SERVICE_ACCOUNT_JSON"]).read_text())
@@ -218,9 +235,8 @@ try:
             data=track_payload,
         )
         release_status = "completed"
-    except urllib.error.HTTPError as exc:
-        error_body = exc.read().decode("utf-8", errors="replace")
-        if "Only releases with status draft may be created on draft app" not in error_body:
+    except ApiHttpError as exc:
+        if "Only releases with status draft may be created on draft app" not in exc.body:
             raise
         track_payload["releases"][0]["status"] = "draft"
         api_json(
@@ -231,11 +247,21 @@ try:
         )
         release_status = "draft"
 
-    api_json(
-        token,
-        "POST",
-        f"https://androidpublisher.googleapis.com/androidpublisher/v3/applications/{package_name}/edits/{edit['id']}:commit",
-    )
+    commit_url = f"https://androidpublisher.googleapis.com/androidpublisher/v3/applications/{package_name}/edits/{edit['id']}:commit"
+    try:
+        api_json(
+            token,
+            "POST",
+            commit_url,
+        )
+    except ApiHttpError as exc:
+        if exc.status_code != 400 or "changesNotSentForReview" not in exc.body:
+            raise
+        api_json(
+            token,
+            "POST",
+            f"{commit_url}?changesNotSentForReview=true",
+        )
 finally:
     try:
         api_json(

--- a/Scripts/publish-android-to-play.sh
+++ b/Scripts/publish-android-to-play.sh
@@ -1,0 +1,250 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: publish-android-to-play.sh --package-name <package> --track <track> --bundle-file <path> --release-name <name> --version-code <code>
+
+Required environment:
+  GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64
+EOF
+}
+
+PACKAGE_NAME=""
+TRACK=""
+BUNDLE_FILE=""
+RELEASE_NAME=""
+VERSION_CODE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --package-name)
+      PACKAGE_NAME="${2:-}"
+      shift 2
+      ;;
+    --track)
+      TRACK="${2:-}"
+      shift 2
+      ;;
+    --bundle-file)
+      BUNDLE_FILE="${2:-}"
+      shift 2
+      ;;
+    --release-name)
+      RELEASE_NAME="${2:-}"
+      shift 2
+      ;;
+    --version-code)
+      VERSION_CODE="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      print -u2 -- "Unknown argument: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$PACKAGE_NAME" || -z "$TRACK" || -z "$BUNDLE_FILE" || -z "$RELEASE_NAME" || -z "$VERSION_CODE" ]]; then
+  usage
+  exit 1
+fi
+
+if [[ ! -f "$BUNDLE_FILE" ]]; then
+  print -u2 -- "Bundle file not found: $BUNDLE_FILE"
+  exit 1
+fi
+
+if [[ -z "${GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64:-}" ]]; then
+  print -u2 -- "GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64 is required."
+  exit 1
+fi
+
+SERVICE_ACCOUNT_JSON="$(mktemp)"
+trap 'rm -f "$SERVICE_ACCOUNT_JSON"' EXIT
+
+python3 <<'PY' > "$SERVICE_ACCOUNT_JSON"
+import base64
+import os
+import sys
+
+sys.stdout.buffer.write(base64.b64decode(os.environ["GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64"]))
+PY
+
+PACKAGE_NAME="$PACKAGE_NAME" \
+TRACK="$TRACK" \
+BUNDLE_FILE="$BUNDLE_FILE" \
+RELEASE_NAME="$RELEASE_NAME" \
+VERSION_CODE="$VERSION_CODE" \
+SERVICE_ACCOUNT_JSON="$SERVICE_ACCOUNT_JSON" \
+python3 <<'PY'
+import base64
+import json
+import os
+import pathlib
+import subprocess
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+def b64url(data: bytes) -> bytes:
+    return base64.urlsafe_b64encode(data).rstrip(b"=")
+
+
+def build_token(service_account: dict) -> str:
+    now = int(time.time())
+    header = b64url(json.dumps({"alg": "RS256", "typ": "JWT"}, separators=(",", ":")).encode())
+    payload = b64url(
+        json.dumps(
+            {
+                "iss": service_account["client_email"],
+                "scope": "https://www.googleapis.com/auth/androidpublisher",
+                "aud": service_account["token_uri"],
+                "iat": now,
+                "exp": now + 3600,
+            },
+            separators=(",", ":"),
+        ).encode()
+    )
+    message = header + b"." + payload
+
+    with tempfile.NamedTemporaryFile("w", delete=False) as key_file:
+        key_file.write(service_account["private_key"])
+        key_path = key_file.name
+
+    try:
+        signature = subprocess.check_output(
+            ["openssl", "dgst", "-sha256", "-sign", key_path],
+            input=message,
+        )
+    finally:
+        os.unlink(key_path)
+
+    assertion = (message + b"." + b64url(signature)).decode()
+    body = urllib.parse.urlencode(
+        {
+            "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            "assertion": assertion,
+        }
+    ).encode()
+    request = urllib.request.Request(
+        service_account["token_uri"],
+        data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    with urllib.request.urlopen(request) as response:
+        return json.loads(response.read())["access_token"]
+
+
+def api_json(token: str, method: str, url: str, data=None, content_type: str = "application/json"):
+    payload = data
+    if data is not None and isinstance(data, (dict, list)):
+        payload = json.dumps(data).encode()
+    request = urllib.request.Request(
+        url,
+        data=payload,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": content_type,
+        },
+    )
+    with urllib.request.urlopen(request) as response:
+        body = response.read()
+        return json.loads(body) if body else None
+
+
+service_account = json.loads(pathlib.Path(os.environ["SERVICE_ACCOUNT_JSON"]).read_text())
+package_name = os.environ["PACKAGE_NAME"]
+track = os.environ["TRACK"]
+bundle_path = pathlib.Path(os.environ["BUNDLE_FILE"])
+release_name = os.environ["RELEASE_NAME"]
+version_code = int(os.environ["VERSION_CODE"])
+
+token = build_token(service_account)
+edit = api_json(
+    token,
+    "POST",
+    f"https://androidpublisher.googleapis.com/androidpublisher/v3/applications/{package_name}/edits",
+    data={},
+)
+
+try:
+    upload_request = urllib.request.Request(
+        (
+            "https://androidpublisher.googleapis.com/upload/androidpublisher/v3/"
+            f"applications/{package_name}/edits/{edit['id']}/bundles?uploadType=media"
+        ),
+        data=bundle_path.read_bytes(),
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/octet-stream",
+        },
+    )
+    with urllib.request.urlopen(upload_request) as response:
+        bundle_response = json.loads(response.read())
+
+    uploaded_version_code = int(bundle_response["versionCode"])
+    if uploaded_version_code != version_code:
+        raise RuntimeError(
+            f"Play reported versionCode {uploaded_version_code}, expected {version_code}."
+        )
+
+    track_payload = {
+        "releases": [
+            {
+                "name": release_name,
+                "status": "completed",
+                "versionCodes": [str(uploaded_version_code)],
+            }
+        ]
+    }
+
+    try:
+        api_json(
+            token,
+            "PUT",
+            f"https://androidpublisher.googleapis.com/androidpublisher/v3/applications/{package_name}/edits/{edit['id']}/tracks/{track}",
+            data=track_payload,
+        )
+        release_status = "completed"
+    except urllib.error.HTTPError as exc:
+        error_body = exc.read().decode("utf-8", errors="replace")
+        if "Only releases with status draft may be created on draft app" not in error_body:
+            raise
+        track_payload["releases"][0]["status"] = "draft"
+        api_json(
+            token,
+            "PUT",
+            f"https://androidpublisher.googleapis.com/androidpublisher/v3/applications/{package_name}/edits/{edit['id']}/tracks/{track}",
+            data=track_payload,
+        )
+        release_status = "draft"
+
+    api_json(
+        token,
+        "POST",
+        f"https://androidpublisher.googleapis.com/androidpublisher/v3/applications/{package_name}/edits/{edit['id']}:commit",
+    )
+finally:
+    try:
+        api_json(
+            token,
+            "DELETE",
+            f"https://androidpublisher.googleapis.com/androidpublisher/v3/applications/{package_name}/edits/{edit['id']}",
+        )
+    except Exception:
+        pass
+
+print(f"Published {package_name} versionCode {version_code} to {track} with status {release_status}.")
+PY


### PR DESCRIPTION
## Summary
- add Android Play internal-track publishing to the release workflow
- keep exporting both signed Android `.apk` and `.aab` artifacts for GitHub Actions and GitHub Releases
- document the Google Play upload behavior in the Android signing guide

## Validation
- parsed `.github/workflows/release.yml` with Ruby YAML
- checked `Scripts/publish-android-to-play.sh` with `zsh -n`
- compiled the embedded Python snippets used by the Play publishing script