### PR TITLE
Fix Android refresh push registration and delivery

### DIFF
--- a/Frontend/Android/app/src/main/AndroidManifest.xml
+++ b/Frontend/Android/app/src/main/AndroidManifest.xml
@@ -31,6 +31,11 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="cookey" />
             </intent-filter>
+
+            <intent-filter>
+                <action android:name="wiki.qaq.cookey.OPEN_REQUEST" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
 
         <activity-alias

--- a/Frontend/Android/app/src/main/java/wiki/qaq/cookey/CookeyApplication.kt
+++ b/Frontend/Android/app/src/main/java/wiki/qaq/cookey/CookeyApplication.kt
@@ -8,6 +8,7 @@ import com.google.firebase.messaging.FirebaseMessaging
 import wiki.qaq.cookey.service.LogCategory
 import wiki.qaq.cookey.service.LogStore
 import wiki.qaq.cookey.service.AppIconSettings
+import wiki.qaq.cookey.service.CookeyMessagingService
 import wiki.qaq.cookey.service.PushTokenStore
 
 class CookeyApplication : Application() {
@@ -21,6 +22,7 @@ class CookeyApplication : Application() {
         }
 
         AppIconSettings.synchronizeSelection(this)
+        CookeyMessagingService.ensureNotificationChannel(this)
 
         // Initialize Firebase (safe even without google-services.json for development)
         try {

--- a/Frontend/Android/app/src/main/java/wiki/qaq/cookey/MainActivity.kt
+++ b/Frontend/Android/app/src/main/java/wiki/qaq/cookey/MainActivity.kt
@@ -1,10 +1,12 @@
 package wiki.qaq.cookey
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import wiki.qaq.cookey.service.CookeyMessagingService
 import wiki.qaq.cookey.ui.CookeyApp
 import wiki.qaq.cookey.ui.theme.CookeyTheme
 
@@ -16,7 +18,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             CookeyTheme {
                 CookeyApp(
-                    initialDeepLink = intent?.data?.toString(),
+                    initialDeepLink = extractDeepLink(intent),
                     onNewIntent = { /* updated via onNewIntent */ }
                 )
             }
@@ -27,11 +29,31 @@ class MainActivity : ComponentActivity() {
         super.onNewIntent(intent)
         setIntent(intent)
         // Recompose will pick up the new intent
-        val uri = intent.data?.toString() ?: return
+        val uri = extractDeepLink(intent) ?: return
         setContent {
             CookeyTheme {
                 CookeyApp(initialDeepLink = uri, onNewIntent = {})
             }
+        }
+    }
+
+    private fun extractDeepLink(intent: Intent?): String? {
+        val directUri = intent?.data?.toString()
+        if (!directUri.isNullOrBlank()) {
+            return directUri
+        }
+
+        if (intent?.action != CookeyMessagingService.ACTION_OPEN_REQUEST) {
+            return null
+        }
+
+        val pairKey = intent.extras?.getString("pair_key")?.takeIf { it.isNotBlank() } ?: return null
+        val serverURL = intent.extras?.getString("server_url")?.takeIf { it.isNotBlank() }
+
+        return if (serverURL != null) {
+            "cookey://$pairKey?host=${Uri.encode(serverURL)}"
+        } else {
+            "cookey://$pairKey"
         }
     }
 }

--- a/Frontend/Android/app/src/main/java/wiki/qaq/cookey/service/CookeyMessagingService.kt
+++ b/Frontend/Android/app/src/main/java/wiki/qaq/cookey/service/CookeyMessagingService.kt
@@ -1,8 +1,12 @@
 package wiki.qaq.cookey.service
 
+import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.RingtoneManager
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
@@ -17,8 +21,38 @@ class CookeyMessagingService : FirebaseMessagingService() {
 
     companion object {
         private const val TAG = "CookeyFCM"
-        private const val CHANNEL_ID = "cookey_refresh"
+        const val ACTION_OPEN_REQUEST = "wiki.qaq.cookey.OPEN_REQUEST"
+        private const val CHANNEL_ID = "cookey_refresh_alerts_v2"
+        private const val LEGACY_CHANNEL_ID = "cookey_refresh"
         private const val CHANNEL_NAME = "Login Requests"
+        private val VIBRATION_PATTERN = longArrayOf(0, 250, 150, 250)
+
+        fun ensureNotificationChannel(context: Context) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+                return
+            }
+
+            val soundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
+            val audioAttributes = AudioAttributes.Builder()
+                .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                .build()
+
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_HIGH
+            ).apply {
+                description = "Notifications for login and session refresh requests"
+                enableLights(true)
+                enableVibration(true)
+                vibrationPattern = VIBRATION_PATTERN
+                setSound(soundUri, audioAttributes)
+            }
+            val manager = context.getSystemService(NotificationManager::class.java)
+            manager.deleteNotificationChannel(LEGACY_CHANNEL_ID)
+            manager.createNotificationChannel(channel)
+        }
     }
 
     override fun onNewToken(token: String) {
@@ -66,6 +100,7 @@ class CookeyMessagingService : FirebaseMessagingService() {
         ensureNotificationChannel()
 
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(deepLinkUri)).apply {
+            action = ACTION_OPEN_REQUEST
             setClass(applicationContext, MainActivity::class.java)
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
         }
@@ -80,8 +115,12 @@ class CookeyMessagingService : FirebaseMessagingService() {
         // Determine notification text from data or defaults
         val requestType = message.data["request_type"] ?: "refresh"
         val targetUrl = message.data["target_url"] ?: ""
-        val title = if (requestType == "refresh") "Session Refresh Request" else "Login Request"
-        val body = if (targetUrl.isNotBlank()) {
+        val title = message.data["title"] ?: if (requestType == "refresh") {
+            "Session Refresh Request"
+        } else {
+            "Login Request"
+        }
+        val body = message.data["body"] ?: if (targetUrl.isNotBlank()) {
             "Tap to approve the request for $targetUrl"
         } else {
             "Tap to approve the request"
@@ -91,7 +130,12 @@ class CookeyMessagingService : FirebaseMessagingService() {
             .setSmallIcon(R.mipmap.ic_launcher)
             .setContentTitle(title)
             .setContentText(body)
-            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(body))
+            .setPriority(NotificationCompat.PRIORITY_MAX)
+            .setCategory(NotificationCompat.CATEGORY_REMINDER)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .setDefaults(Notification.DEFAULT_ALL)
+            .setVibrate(VIBRATION_PATTERN)
             .setAutoCancel(true)
             .setContentIntent(pendingIntent)
             .build()
@@ -101,16 +145,6 @@ class CookeyMessagingService : FirebaseMessagingService() {
     }
 
     private fun ensureNotificationChannel() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channel = NotificationChannel(
-                CHANNEL_ID,
-                CHANNEL_NAME,
-                NotificationManager.IMPORTANCE_HIGH
-            ).apply {
-                description = "Notifications for login and session refresh requests"
-            }
-            val manager = getSystemService(NotificationManager::class.java)
-            manager.createNotificationChannel(channel)
-        }
+        ensureNotificationChannel(applicationContext)
     }
 }

--- a/Frontend/Android/app/src/main/java/wiki/qaq/cookey/ui/CookeyApp.kt
+++ b/Frontend/Android/app/src/main/java/wiki/qaq/cookey/ui/CookeyApp.kt
@@ -82,8 +82,8 @@ fun CookeyApp(
         )
         is Phase.NotificationConsent -> NotificationConsentScreen(
             serverHost = currentPhase.serverHost,
-            onEnable = { viewModel.onNotificationConsentDone(context) },
-            onSkip = { viewModel.onNotificationConsentDone(context) }
+            onEnable = { viewModel.onNotificationConsentEnabled(context) },
+            onSkip = { viewModel.onNotificationConsentSkipped(context) }
         )
         is Phase.Uploading -> UploadProgressScreen(isUploading = true)
         is Phase.Done -> UploadProgressScreen(

--- a/Frontend/Android/app/src/main/java/wiki/qaq/cookey/ui/CookeyViewModel.kt
+++ b/Frontend/Android/app/src/main/java/wiki/qaq/cookey/ui/CookeyViewModel.kt
@@ -5,10 +5,12 @@ import android.util.Base64
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.firebase.messaging.FirebaseMessaging
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.serialization.json.Json
 import wiki.qaq.cookey.BuildConfig
 import wiki.qaq.cookey.crypto.DeviceKeyManager
@@ -23,12 +25,18 @@ import wiki.qaq.cookey.service.*
 import java.time.Instant
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
+import kotlin.coroutines.resume
 
 class CookeyViewModel : ViewModel() {
 
     companion object {
         private const val TAG = "CookeyViewModel"
     }
+
+    private data class PendingUpload(
+        val cookies: List<CapturedCookie>,
+        val origins: List<CapturedOrigin>
+    )
 
     private val _phase = MutableStateFlow<Phase>(Phase.Idle)
     val phase = _phase.asStateFlow()
@@ -46,6 +54,7 @@ class CookeyViewModel : ViewModel() {
     private var currentDeepLink: DeepLink? = null
     private var currentClient: RelayClient? = null
     private var pendingKeyVerificationContext: Context? = null
+    private var pendingUpload: PendingUpload? = null
     private var lastHandledIncomingUri: String? = null
 
     private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
@@ -60,6 +69,7 @@ class CookeyViewModel : ViewModel() {
         currentDeepLink = null
         currentClient = null
         seedSession = null
+        pendingUpload = null
         lastHandledIncomingUri = null
         _showKeyVerification.value = false
         _keyVerificationResult.value = null
@@ -307,6 +317,69 @@ class CookeyViewModel : ViewModel() {
             return
         }
 
+        if (shouldPromptForNotificationConsent(context, deepLink.serverURL)) {
+            pendingUpload = PendingUpload(cookies = cookies, origins = origins)
+            val host = deepLink.serverURL
+                .removePrefix("https://")
+                .removePrefix("http://")
+            LogStore.info(context, LogCategory.PUSH, "Prompting for notification consent before first session upload")
+            _phase.value = Phase.NotificationConsent(host)
+            return
+        }
+
+        uploadCapturedSession(context, deepLink, client, cookies, origins)
+    }
+
+    fun onNotificationConsentEnabled(context: Context) {
+        val serverURL = currentDeepLink?.serverURL
+        if (serverURL != null) {
+            AppSettings.setPromptedNotification(context, serverURL)
+        }
+        LogStore.info(context, LogCategory.PUSH, "Notification consent granted; resuming session upload")
+        resumePendingUpload(context)
+    }
+
+    fun onNotificationConsentSkipped(context: Context) {
+        val serverURL = currentDeepLink?.serverURL
+        if (serverURL != null) {
+            AppSettings.setPromptedNotification(context, serverURL)
+        }
+        LogStore.info(context, LogCategory.PUSH, "Notification consent skipped; continuing without device info")
+        resumePendingUpload(context)
+    }
+
+    private fun shouldPromptForNotificationConsent(context: Context, serverURL: String): Boolean {
+        return !AppSettings.getAllowRefresh(context) &&
+            !AppSettings.hasPromptedNotification(context, serverURL)
+    }
+
+    private fun resumePendingUpload(context: Context) {
+        val upload = pendingUpload ?: run {
+            _phase.value = Phase.Done
+            return
+        }
+        val deepLink = currentDeepLink ?: run {
+            pendingUpload = null
+            _phase.value = Phase.Failed("Session upload could not be resumed.")
+            return
+        }
+        val client = currentClient ?: run {
+            pendingUpload = null
+            _phase.value = Phase.Failed("Session upload could not be resumed.")
+            return
+        }
+
+        pendingUpload = null
+        uploadCapturedSession(context, deepLink, client, upload.cookies, upload.origins)
+    }
+
+    private fun uploadCapturedSession(
+        context: Context,
+        deepLink: DeepLink,
+        client: RelayClient,
+        cookies: List<CapturedCookie>,
+        origins: List<CapturedOrigin>
+    ) {
         _phase.value = Phase.Uploading
         LogStore.info(context, LogCategory.NETWORK, "Starting session upload for rid=${deepLink.rid}")
 
@@ -367,16 +440,7 @@ class CookeyViewModel : ViewModel() {
 
                 client.uploadSession(deepLink.rid, envelope)
                 LogStore.info(context, LogCategory.NETWORK, "Session uploaded successfully")
-
-                // Show notification consent if not yet prompted for this server
-                if (!AppSettings.getAllowRefresh(context) &&
-                    !AppSettings.hasPromptedNotification(context, deepLink.serverURL)) {
-                    val host = deepLink.serverURL
-                        .removePrefix("https://").removePrefix("http://")
-                    _phase.value = Phase.NotificationConsent(host)
-                } else {
-                    _phase.value = Phase.Done
-                }
+                _phase.value = Phase.Done
             } catch (e: RelayException) {
                 LogStore.error(context, LogCategory.NETWORK, "Upload server error: ${e.code} ${e.message}")
                 _phase.value = Phase.Failed(UploadError.ServerError(e.code, e.message ?: "Unknown").userMessage)
@@ -388,18 +452,13 @@ class CookeyViewModel : ViewModel() {
         }
     }
 
-    fun onNotificationConsentDone(context: Context) {
-        val serverURL = currentDeepLink?.serverURL
-        if (serverURL != null) {
-            AppSettings.setPromptedNotification(context, serverURL)
-        }
-        _phase.value = Phase.Done
-    }
-
-    private fun buildDeviceInfo(context: Context, deviceID: String): DeviceInfo? {
+    private suspend fun buildDeviceInfo(context: Context, deviceID: String): DeviceInfo? {
         if (!AppSettings.getAllowRefresh(context)) return null
 
-        val fcmToken = PushTokenStore.getToken(context) ?: return null
+        val fcmToken = ensureFCMToken(context) ?: run {
+            LogStore.info(context, LogCategory.PUSH, "Refresh is enabled, but no FCM token is available yet")
+            return null
+        }
         val publicKeyBase64 = try {
             Base64.encodeToString(DeviceKeyManager.publicKey(context), Base64.NO_WRAP)
         } catch (_: Exception) {
@@ -412,5 +471,35 @@ class CookeyViewModel : ViewModel() {
             fcmToken = fcmToken,
             publicKey = publicKeyBase64
         )
+    }
+
+    private suspend fun ensureFCMToken(context: Context): String? {
+        PushTokenStore.getToken(context)?.let { return it }
+
+        return try {
+            val token = suspendCancellableCoroutine<String?> { continuation ->
+                FirebaseMessaging.getInstance().token
+                    .addOnSuccessListener { value ->
+                        val tokenValue = value?.takeIf { it.isNotBlank() }
+                        if (continuation.isActive) {
+                            continuation.resume(tokenValue)
+                        }
+                    }
+                    .addOnFailureListener { error ->
+                        LogStore.error(context, LogCategory.PUSH, "FCM token fetch failed during upload: ${error.message}")
+                        if (continuation.isActive) {
+                            continuation.resume(null)
+                        }
+                    }
+            }
+
+            token?.also {
+                PushTokenStore.setToken(context, it)
+                LogStore.info(context, LogCategory.PUSH, "FCM token obtained on demand before session upload")
+            }
+        } catch (e: Exception) {
+            LogStore.error(context, LogCategory.PUSH, "FCM token fetch error during upload: ${e.message}")
+            null
+        }
     }
 }

--- a/Server/fcm.go
+++ b/Server/fcm.go
@@ -72,18 +72,22 @@ func (c *FCMClient) sendNotification(request *StoredRequest, serverURL string, t
 	payload := fcmV1Request{
 		Message: fcmMessage{
 			Token: token,
-			Notification: &fcmNotification{
-				Title: title,
-				Body:  body,
-			},
 			Data: map[string]string{
+				"body":         body,
 				"pair_key":     request.PairKey,
 				"server_url":   serverURL,
 				"request_type": request.RequestType,
 				"target_url":   request.TargetURL,
+				"title":        title,
 			},
 			Android: &fcmAndroid{
 				Priority: "high",
+				Notification: &fcmAndroidNotification{
+					ChannelID:   "cookey_refresh_alerts_v2",
+					ClickAction: "wiki.qaq.cookey.OPEN_REQUEST",
+					Body:        body,
+					Title:       title,
+				},
 			},
 		},
 	}
@@ -248,7 +252,15 @@ type fcmNotification struct {
 }
 
 type fcmAndroid struct {
-	Priority string `json:"priority,omitempty"`
+	Priority     string                  `json:"priority,omitempty"`
+	Notification *fcmAndroidNotification `json:"notification,omitempty"`
+}
+
+type fcmAndroidNotification struct {
+	Body        string `json:"body,omitempty"`
+	ChannelID   string `json:"channel_id,omitempty"`
+	ClickAction string `json:"click_action,omitempty"`
+	Title       string `json:"title,omitempty"`
 }
 
 type serviceAccountKey struct {

--- a/Server/main.go
+++ b/Server/main.go
@@ -19,6 +19,11 @@ func main() {
 	log.Printf("   Public URL: %s", config.PublicURL)
 	log.Printf("   Default TTL: %ds", int(config.DefaultTTL.Seconds()))
 	log.Printf("   Max Payload: %dKB", config.MaxPayloadSize/1024)
+	if config.DisablePushRateLimit {
+		log.Println("   Push Rate Limit: disabled")
+	} else {
+		log.Println("   Push Rate Limit: enabled")
+	}
 	if config.APNSConfiguration != nil {
 		log.Println("   APNs: enabled")
 	} else {
@@ -32,7 +37,10 @@ func main() {
 
 	storage := NewStorage(config.MaxPayloadSize)
 	apnBlocker := NewAPNTokenBlocker()
-	pushLimiter := NewAPNPushRateLimiter()
+	var pushLimiter *APNPushRateLimiter
+	if !config.DisablePushRateLimit {
+		pushLimiter = NewAPNPushRateLimiter()
+	}
 
 	var apnsClient notificationSender
 	if config.APNSConfiguration != nil {
@@ -163,6 +171,11 @@ func parseConfig(args []string) ServerConfig {
 	if v := os.Getenv("COOKEY_PUBLIC_URL"); v != "" {
 		config.PublicURL = v
 	}
+	if v := os.Getenv("COOKEY_DISABLE_PUSH_RATE_LIMIT"); v != "" {
+		if disabled, err := strconv.ParseBool(v); err == nil {
+			config.DisablePushRateLimit = disabled
+		}
+	}
 
 	// Default public URL if not set
 	if config.PublicURL == "" {
@@ -242,6 +255,7 @@ Environment Variables:
   COOKEY_HOST             Bind host
   COOKEY_PORT             Bind port
   COOKEY_PUBLIC_URL       Public URL
+  COOKEY_DISABLE_PUSH_RATE_LIMIT Disable APNs/FCM push rate limiting for testing
   COOKEY_APNS_TEAM_ID     Apple Developer team ID
   COOKEY_APNS_KEY_ID      APNs key ID
   COOKEY_APNS_BUNDLE_ID   App bundle identifier

--- a/Server/models.go
+++ b/Server/models.go
@@ -117,15 +117,15 @@ func NewRequestStatusResponse(r *StoredRequest) RequestStatusResponse {
 // PairKeyResponse is the JSON response for pair key resolution.
 // Fields ordered alphabetically by JSON tag.
 type PairKeyResponse struct {
-	CLIPublicKey string      `json:"cli_public_key"`
-	DeviceID     string      `json:"device_id"`
-	ExpiresAt    ISO8601Time `json:"expires_at"`
-	RID          string      `json:"rid"`
+	CLIPublicKey  string      `json:"cli_public_key"`
+	DeviceID      string      `json:"device_id"`
+	ExpiresAt     ISO8601Time `json:"expires_at"`
+	RID           string      `json:"rid"`
 	RequestProof  string      `json:"request_proof"`
 	RequestSecret string      `json:"request_secret"`
 	RequestType   string      `json:"request_type"`
-	ServerURL    string      `json:"server_url"`
-	TargetURL    string      `json:"target_url"`
+	ServerURL     string      `json:"server_url"`
+	TargetURL     string      `json:"target_url"`
 }
 
 const (
@@ -193,13 +193,14 @@ type ErrorPayload struct {
 
 // ServerConfig holds the server configuration.
 type ServerConfig struct {
-	Host              string
-	Port              int
-	DefaultTTL        time.Duration
-	MaxPayloadSize    int
-	PublicURL         string
-	APNSConfiguration *APNSConfiguration
-	FCMConfiguration  *FCMConfiguration
+	Host                 string
+	Port                 int
+	DefaultTTL           time.Duration
+	MaxPayloadSize       int
+	PublicURL            string
+	DisablePushRateLimit bool
+	APNSConfiguration    *APNSConfiguration
+	FCMConfiguration     *FCMConfiguration
 }
 
 // APNSConfiguration holds APNs push notification settings.


### PR DESCRIPTION
## Summary
- ask for notification consent before the first Android session upload and fetch an FCM token on demand
- improve Android refresh notification delivery for background launches by precreating the channel and rebuilding requests from FCM notification taps
- add a server flag to disable push rate limiting during local testing and update the FCM payload accordingly

## Testing
- `./gradlew :app:compileDebugKotlin`
- `go test ./...`
- local device validation with FCM quick tunnel testing on two Android devices