### PR TITLE
Add native Windows support for the CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,39 @@ jobs:
           path: build/releases/${{ needs.prepare.outputs.build_version }}/cookey-${{ needs.prepare.outputs.build_version }}-linux-aarch64.zip
           if-no-files-found: error
 
+  build_windows_x86_64:
+    if: github.actor == 'Lakr233' || github.actor == 'eyhn'
+    name: Build Windows x86_64 CLI
+    runs-on: ubuntu-latest
+    needs: prepare
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: CommandLineTool/go.mod
+
+      - name: Build and package Windows x86_64 CLI
+        run: |
+          set -euo pipefail
+          TAG="${{ needs.prepare.outputs.build_version }}"
+          RELEASE_DIR="build/releases/${TAG}"
+          mkdir -p "${RELEASE_DIR}"
+          (
+            cd CommandLineTool
+            GOOS=windows GOARCH=amd64 go build -o "../${RELEASE_DIR}/cookey.exe" .
+          )
+          rm -f "${RELEASE_DIR}/cookey-${TAG}-windows-x86_64.zip"
+          zip -j "${RELEASE_DIR}/cookey-${TAG}-windows-x86_64.zip" "${RELEASE_DIR}/cookey.exe"
+
+      - name: Upload Windows x86_64 artifact
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          name: cookey-${{ needs.prepare.outputs.build_version }}-windows-x86_64
+          path: build/releases/${{ needs.prepare.outputs.build_version }}/cookey-${{ needs.prepare.outputs.build_version }}-windows-x86_64.zip
+          if-no-files-found: error
+
   build_android:
     if: github.actor == 'Lakr233' || github.actor == 'eyhn'
     name: Build Android release bundle
@@ -317,6 +350,7 @@ jobs:
       - prepare
       - build_linux_x86_64
       - build_linux_aarch64
+      - build_windows_x86_64
       - build_android
       - sign_notarize_macos
     steps:
@@ -340,6 +374,12 @@ jobs:
           name: cookey-${{ needs.prepare.outputs.build_version }}-linux-aarch64
           path: build/release-assets/linux-aarch64
 
+      - name: Download Windows x86_64 artifact
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: cookey-${{ needs.prepare.outputs.build_version }}-windows-x86_64
+          path: build/release-assets/windows-x86_64
+
       - name: Download Android artifact
         uses: actions/download-artifact@v8.0.1
         with:
@@ -353,6 +393,7 @@ jobs:
           cp "build/release-assets/macos/cookey-${{ needs.prepare.outputs.build_version }}-macOS-cli.zip" "build/release-assets/final/cookey-macOS.zip"
           cp "build/release-assets/linux-x86_64/cookey-${{ needs.prepare.outputs.build_version }}-linux-x86_64.zip" "build/release-assets/final/cookey-linux-x86_64.zip"
           cp "build/release-assets/linux-aarch64/cookey-${{ needs.prepare.outputs.build_version }}-linux-aarch64.zip" "build/release-assets/final/cookey-linux-aarch64.zip"
+          cp "build/release-assets/windows-x86_64/cookey-${{ needs.prepare.outputs.build_version }}-windows-x86_64.zip" "build/release-assets/final/cookey-windows-x86_64.zip"
           cp "build/release-assets/android/cookey-android.apk" "build/release-assets/final/cookey-android.apk"
           cp "build/release-assets/android/cookey-android.aab" "build/release-assets/final/cookey-android.aab"
           cp skills/website-login/SKILL.md build/release-assets/final/skills.md

--- a/CommandLineTool/AGENTS.md
+++ b/CommandLineTool/AGENTS.md
@@ -1,6 +1,6 @@
 # CommandLineTool
 
-Go executable module targeting macOS 13+ and Linux. The `cookey` binary is the user-facing CLI tool.
+Go executable module targeting macOS 13+, Linux, and Windows x64. The `cookey` binary is the user-facing CLI tool.
 
 ## Dependencies
 
@@ -79,7 +79,7 @@ Go executable module targeting macOS 13+ and Linux. The `cookey` binary is the u
 ## Daemon Process Model
 
 - Default behavior is detached. `request start` / `request refresh` call `daemon.LaunchDetached`, which re-executes the current binary as `cookey __daemon <payload>`.
-- Detached daemons start in a new session with `setsid`, and stdin/stdout/stderr are redirected to `/dev/null`.
+- Detached daemons start with platform-specific background process settings, and stdin/stdout/stderr are redirected to the platform null device.
 - The parent CLI process waits only until the daemon descriptor file is written, then returns success to the caller.
 - `--attach` skips detached launch and runs the same wait/decrypt/write flow inline via `daemon.RunInline`.
 - Inline mode means the current process must stay alive until delivery completes. This is only safe when the caller intentionally keeps the process attached.

--- a/CommandLineTool/internal/config/process_unix.go
+++ b/CommandLineTool/internal/config/process_unix.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package config
+
+import (
+	"errors"
+	"syscall"
+)
+
+func IsProcessAlive(pid int32) bool {
+	if pid <= 0 {
+		return false
+	}
+
+	err := syscall.Kill(int(pid), 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}

--- a/CommandLineTool/internal/config/process_windows.go
+++ b/CommandLineTool/internal/config/process_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package config
+
+import "golang.org/x/sys/windows"
+
+const windowsStillActive = 259
+
+func IsProcessAlive(pid int32) bool {
+	if pid <= 0 {
+		return false
+	}
+
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(handle)
+
+	var exitCode uint32
+	if err := windows.GetExitCodeProcess(handle, &exitCode); err != nil {
+		return false
+	}
+
+	return exitCode == windowsStillActive
+}

--- a/CommandLineTool/internal/config/store.go
+++ b/CommandLineTool/internal/config/store.go
@@ -6,12 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
-	"syscall"
 	"time"
 
 	"cookey/internal/crypto"
@@ -416,15 +414,6 @@ func StatusSnapshot(rid string, context BootstrapContext) models.StatusSnapshot 
 	}
 }
 
-func IsProcessAlive(pid int32) bool {
-	if pid <= 0 {
-		return false
-	}
-
-	err := syscall.Kill(int(pid), 0)
-	return err == nil || errors.Is(err, syscall.EPERM)
-}
-
 func WriteSession(session models.SessionFile, rid string, paths AppPaths) error {
 	return WriteJSON(paths.SessionPath(rid), session, 0o600)
 }
@@ -628,34 +617,6 @@ func removeIfExists(path string) (bool, error) {
 		return false, err
 	}
 	return true, nil
-}
-
-func currentOSVersionString() string {
-	if runtime.GOOS == "darwin" {
-		productVersion, errVersion := exec.Command("sw_vers", "-productVersion").Output()
-		buildVersion, errBuild := exec.Command("sw_vers", "-buildVersion").Output()
-		if errVersion == nil && errBuild == nil {
-			return "Version " + strings.TrimSpace(string(productVersion)) + " (Build " + strings.TrimSpace(string(buildVersion)) + ")"
-		}
-	}
-
-	return runtime.GOOS
-}
-
-func machineIdentifier() string {
-	for _, candidate := range []string{"/etc/machine-id", "/var/lib/dbus/machine-id"} {
-		data, err := os.ReadFile(candidate)
-		if err != nil {
-			continue
-		}
-
-		value := strings.TrimSpace(string(data))
-		if value != "" {
-			return value
-		}
-	}
-
-	return ""
 }
 
 func currentArchitecture() string {

--- a/CommandLineTool/internal/config/store_test.go
+++ b/CommandLineTool/internal/config/store_test.go
@@ -2,16 +2,21 @@ package config
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"cookey/internal/models"
 )
 
+func setTestHomeDir(t *testing.T, homeDir string) {
+	t.Helper()
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+}
+
 func TestBootstrapDoesNotCreateIdentityByDefault(t *testing.T) {
 	homeDir := t.TempDir()
-	t.Setenv("HOME", homeDir)
+	setTestHomeDir(t, homeDir)
 
 	context, err := Bootstrap()
 	if err != nil {
@@ -35,9 +40,9 @@ func TestBootstrapDoesNotCreateIdentityByDefault(t *testing.T) {
 	}
 
 	for _, dir := range []string{
-		filepath.Join(homeDir, ".cookey"),
-		filepath.Join(homeDir, ".cookey", "sessions"),
-		filepath.Join(homeDir, ".cookey", "daemons"),
+		context.Paths.Root,
+		context.Paths.Sessions,
+		context.Paths.Daemons,
 	} {
 		if !fileExists(dir) {
 			t.Fatalf("Bootstrap() missing directory %q", dir)
@@ -47,7 +52,7 @@ func TestBootstrapDoesNotCreateIdentityByDefault(t *testing.T) {
 
 func TestBootstrapWithIdentityCreatesAndReusesIdentity(t *testing.T) {
 	homeDir := t.TempDir()
-	t.Setenv("HOME", homeDir)
+	setTestHomeDir(t, homeDir)
 
 	first, err := BootstrapWithIdentity()
 	if err != nil {

--- a/CommandLineTool/internal/config/systeminfo_unix.go
+++ b/CommandLineTool/internal/config/systeminfo_unix.go
@@ -1,0 +1,38 @@
+//go:build !windows
+
+package config
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+func currentOSVersionString() string {
+	if runtime.GOOS == "darwin" {
+		productVersion, errVersion := exec.Command("sw_vers", "-productVersion").Output()
+		buildVersion, errBuild := exec.Command("sw_vers", "-buildVersion").Output()
+		if errVersion == nil && errBuild == nil {
+			return "Version " + strings.TrimSpace(string(productVersion)) + " (Build " + strings.TrimSpace(string(buildVersion)) + ")"
+		}
+	}
+
+	return runtime.GOOS
+}
+
+func machineIdentifier() string {
+	for _, candidate := range []string{"/etc/machine-id", "/var/lib/dbus/machine-id"} {
+		data, err := os.ReadFile(candidate)
+		if err != nil {
+			continue
+		}
+
+		value := strings.TrimSpace(string(data))
+		if value != "" {
+			return value
+		}
+	}
+
+	return ""
+}

--- a/CommandLineTool/internal/config/systeminfo_windows.go
+++ b/CommandLineTool/internal/config/systeminfo_windows.go
@@ -1,0 +1,56 @@
+//go:build windows
+
+package config
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+func currentOSVersionString() string {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.QUERY_VALUE)
+	if err != nil {
+		return runtime.GOOS
+	}
+	defer key.Close()
+
+	productName, _, _ := key.GetStringValue("ProductName")
+	displayVersion, _, _ := key.GetStringValue("DisplayVersion")
+	if displayVersion == "" {
+		displayVersion, _, _ = key.GetStringValue("ReleaseId")
+	}
+	buildNumber, _, _ := key.GetStringValue("CurrentBuildNumber")
+
+	parts := make([]string, 0, 3)
+	if value := strings.TrimSpace(productName); value != "" {
+		parts = append(parts, value)
+	}
+	if value := strings.TrimSpace(displayVersion); value != "" {
+		parts = append(parts, value)
+	}
+	if value := strings.TrimSpace(buildNumber); value != "" {
+		parts = append(parts, fmt.Sprintf("Build %s", value))
+	}
+	if len(parts) == 0 {
+		return runtime.GOOS
+	}
+
+	return strings.Join(parts, " ")
+}
+
+func machineIdentifier() string {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Cryptography`, registry.QUERY_VALUE)
+	if err != nil {
+		return ""
+	}
+	defer key.Close()
+
+	value, _, err := key.GetStringValue("MachineGuid")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(value)
+}

--- a/CommandLineTool/internal/daemon/daemon.go
+++ b/CommandLineTool/internal/daemon/daemon.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
-	"syscall"
 	"time"
 
 	"cookey/internal/config"
@@ -39,16 +38,11 @@ func LaunchDetached(context config.BootstrapContext, manifest models.LoginManife
 	}
 
 	command := exec.Command(executablePath, "__daemon", encodedPayload)
-	command.Stdin = nil
-	devNull, err := os.OpenFile("/dev/null", os.O_RDWR, 0)
+	devNull, err := configureDetachedProcess(command)
 	if err != nil {
 		return 0, err
 	}
 	defer devNull.Close()
-	command.Stdin = devNull
-	command.Stdout = devNull
-	command.Stderr = devNull
-	command.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 
 	if err := command.Start(); err != nil {
 		return 0, err

--- a/CommandLineTool/internal/daemon/detach_unix.go
+++ b/CommandLineTool/internal/daemon/detach_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func configureDetachedProcess(command *exec.Cmd) (*os.File, error) {
+	devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	command.Stdin = devNull
+	command.Stdout = devNull
+	command.Stderr = devNull
+	command.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	return devNull, nil
+}

--- a/CommandLineTool/internal/daemon/detach_windows.go
+++ b/CommandLineTool/internal/daemon/detach_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package daemon
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+const (
+	windowsCreateNewProcessGroup = 0x00000200
+	windowsDetachedProcess       = 0x00000008
+)
+
+func configureDetachedProcess(command *exec.Cmd) (*os.File, error) {
+	devNull, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	command.Stdin = devNull
+	command.Stdout = devNull
+	command.Stderr = devNull
+	command.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windowsCreateNewProcessGroup | windowsDetachedProcess,
+		HideWindow:    true,
+	}
+	return devNull, nil
+}

--- a/CommandLineTool/npm/lib/platform.js
+++ b/CommandLineTool/npm/lib/platform.js
@@ -30,6 +30,13 @@ const TARGETS = {
     packageName: "@cookey/cli-linux-arm64",
     packageDirName: "cli-linux-arm64",
   },
+  "win32-x64": {
+    platform: "win32",
+    arch: "x64",
+    binaryName: "cookey.exe",
+    packageName: "@cookey/cli-windows-x64",
+    packageDirName: "cli-windows-x64",
+  },
 };
 
 function formatTarget(platform = process.platform, arch = process.arch) {

--- a/CommandLineTool/pip/cookey_cli/launcher.py
+++ b/CommandLineTool/pip/cookey_cli/launcher.py
@@ -28,6 +28,11 @@ TARGETS = {
         "arch": "arm64",
         "binary_name": "cookey-linux-arm64",
     },
+    "win32-x64": {
+        "platform": "win32",
+        "arch": "x64",
+        "binary_name": "cookey-win32-x64.exe",
+    },
 }
 
 
@@ -46,6 +51,11 @@ def detect_target() -> dict[str, str]:
             runtime_arch = "x64"
         elif machine in {"aarch64", "arm64"}:
             runtime_arch = "arm64"
+        else:
+            runtime_arch = machine
+    elif runtime_platform == "win32":
+        if machine in {"x86_64", "amd64"}:
+            runtime_arch = "x64"
         else:
             runtime_arch = machine
     else:
@@ -69,9 +79,10 @@ def resolve_binary_path() -> str:
         )
 
     path = os.fspath(binary)
-    mode = os.stat(path).st_mode
-    if not mode & stat.S_IXUSR:
-        os.chmod(path, mode | stat.S_IXUSR)
+    if sys.platform != "win32":
+        mode = os.stat(path).st_mode
+        if not mode & stat.S_IXUSR:
+            os.chmod(path, mode | stat.S_IXUSR)
     return path
 
 

--- a/CommandLineTool/pip/pyproject.toml
+++ b/CommandLineTool/pip/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
   "Environment :: Console",
   "Operating System :: MacOS",
   "Operating System :: POSIX :: Linux",
+  "Operating System :: Microsoft :: Windows",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
   "Topic :: Utilities",

--- a/CommandLineTool/scripts/build-targets.mjs
+++ b/CommandLineTool/scripts/build-targets.mjs
@@ -35,10 +35,21 @@ export const targets = [
     arch: "arm64",
     exe: false,
   },
+  {
+    goos: "windows",
+    goarch: "amd64",
+    platform: "win32",
+    arch: "x64",
+    exe: true,
+  },
 ];
 
+function platformLabel(platform) {
+  return platform === "win32" ? "windows" : platform;
+}
+
 export function formatTarget(target) {
-  return `${target.platform}-${target.arch}`;
+  return `${platformLabel(target.platform)}-${target.arch}`;
 }
 
 export function binaryName(target) {
@@ -46,11 +57,11 @@ export function binaryName(target) {
 }
 
 export function releaseAssetName(version, target) {
-  return `cookey-v${version}-${target.platform}-${target.arch}${target.exe ? ".exe" : ""}`;
+  return `cookey-v${version}-${platformLabel(target.platform)}-${target.arch}${target.exe ? ".exe" : ""}`;
 }
 
 export function platformPackageDirName(target) {
-  return `cli-${target.platform}-${target.arch}`;
+  return `cli-${platformLabel(target.platform)}-${target.arch}`;
 }
 
 export function platformPackageName(target) {

--- a/Frontend/Android/app/src/main/java/wiki/qaq/cookey/ui/welcome/WelcomeScreen.kt
+++ b/Frontend/Android/app/src/main/java/wiki/qaq/cookey/ui/welcome/WelcomeScreen.kt
@@ -162,7 +162,7 @@ private fun InstallPage() {
     val context = LocalContext.current
     var copied by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
-    val installCommand = "npx cookey@latest"
+    val installCommand = "npx @cookey/cli@latest"
 
     PageContainer {
         Icon(

--- a/Web/public/llms.txt
+++ b/Web/public/llms.txt
@@ -6,12 +6,16 @@ Cookey captures authenticated browser sessions from a mobile device and delivers
 them encrypted to a CLI terminal as Playwright-compatible `storageState` JSON.
 
 ## Install
-Download the latest binary from GitHub Releases:
-  https://github.com/Lakr233/Cookey/releases/latest/download/cookey-macOS.zip
+Install from npm:
+  npm install -g @cookey/cli
+
+Or download the latest binary from GitHub Releases:
 
 Assets:
   https://github.com/Lakr233/Cookey/releases/latest/download/cookey-macOS.zip
     macOS universal (arm64 + x86_64), signed & notarized
+  https://github.com/Lakr233/Cookey/releases/latest/download/cookey-windows-x86_64.zip
+    Windows x86_64
   https://github.com/Lakr233/Cookey/releases/latest/download/cookey-linux-x86_64.zip
     Linux x86_64
   https://github.com/Lakr233/Cookey/releases/latest/download/cookey-linux-aarch64.zip

--- a/skills/website-login/SKILL.md
+++ b/skills/website-login/SKILL.md
@@ -32,6 +32,7 @@ pip install cookey
 Alternatively, download prebuilt binaries:
 
 - macOS: https://github.com/Lakr233/Cookey/releases/latest/download/cookey-macOS.zip
+- Windows x86_64: https://github.com/Lakr233/Cookey/releases/latest/download/cookey-windows-x86_64.zip
 - Linux x86_64: https://github.com/Lakr233/Cookey/releases/latest/download/cookey-linux-x86_64.zip
 - Linux aarch64: https://github.com/Lakr233/Cookey/releases/latest/download/cookey-linux-aarch64.zip
 


### PR DESCRIPTION
## Summary
- add native Windows x64 support to the CLI runtime and detached daemon flow
- publish Windows CLI artifacts for GitHub Releases, npm, and pip launchers
- update install and onboarding copy to point Windows users to the native path

## Testing
- go test ./... (in `CommandLineTool`)
- GOOS=windows GOARCH=amd64 go build ./...
- GOOS=linux GOARCH=amd64 go build ./...
- node ./scripts/build-npm-package.mjs
- node ./scripts/build-pip-package.mjs
- node ./dist/npm/cli/bin/cookey.js --help