### PR TITLE
[codex] Set Android browser user agent

### DIFF
--- a/Frontend/Android/app/src/main/java/wiki/qaq/cookey/ui/browser/BrowserScreen.kt
+++ b/Frontend/Android/app/src/main/java/wiki/qaq/cookey/ui/browser/BrowserScreen.kt
@@ -68,6 +68,9 @@ private const val HISTORY_BACK_GUARD_JS = """
 })();
 """
 
+private const val ANDROID_BROWSER_USER_AGENT =
+    "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36"
+
 @OptIn(ExperimentalMaterial3Api::class)
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
@@ -118,6 +121,7 @@ fun BrowserScreen(
             domStorageEnabled = true
             setSupportMultipleWindows(true)
             javaScriptCanOpenWindowsAutomatically = true
+            userAgentString = ANDROID_BROWSER_USER_AGENT
         }
 
         candidate.webViewClient = object : WebViewClient() {


### PR DESCRIPTION
## Summary

Sets the Android in-app browser WebView user agent to a Chrome Android-style string:

`Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Mobile Safari/537.36`

This keeps Cookey's captured browsing flow from exposing the default Android WebView `wv` marker in the HTTP user-agent header.

## Validation

- Ran `./gradlew installDebug` from `Frontend/Android`
- Opened Cookey through the normal deep link request flow targeting `https://httpbin.org/user-agent`
- Confirmed httpbin returned the configured user-agent string in the in-app browser
