### PR TITLE
[codex] Bump version to 0.4.14

### DIFF
--- a/CommandLineTool/internal/cli/version.go
+++ b/CommandLineTool/internal/cli/version.go
@@ -1,3 +1,3 @@
 package cli
 
-var Version = "0.4.11"
+var Version = "0.4.14"

--- a/Frontend/Apple/Cookey.xcodeproj/project.pbxproj
+++ b/Frontend/Apple/Cookey.xcodeproj/project.pbxproj
@@ -473,7 +473,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.4.13;
+				MARKETING_VERSION = 0.4.14;
 				PRODUCT_BUNDLE_IDENTIFIER = wiki.qaq.cookey.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -541,7 +541,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.4.13;
+				MARKETING_VERSION = 0.4.14;
 				PRODUCT_BUNDLE_IDENTIFIER = wiki.qaq.cookey.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
## Summary

Bumps Cookey release metadata to `0.4.14`.

This updates:

- CLI version source used by `cookey version`, npm package generation, and pip package generation
- Apple app `MARKETING_VERSION` in the Xcode project

## Validation

- Ran `go test ./...` in `CommandLineTool`
- Ran `go run . version` in `CommandLineTool` and confirmed `0.4.14`
- Ran `node ./scripts/build-npm-package.mjs` and confirmed generated npm package versions are `0.4.14`
